### PR TITLE
Enable production build configuration (#7)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,13 +27,15 @@
               "src/styles.css"
             ],
             "scripts": [],
-            "extractLicenses": false,
-            "sourceMap": true,
-            "optimization": false,
-            "namedChunks": true,
             "browser": "src/main.ts"
           },
           "configurations": {
+            "development": {
+              "extractLicenses": false,
+              "sourceMap": true,
+              "optimization": false,
+              "namedChunks": true
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -60,7 +62,7 @@
               ]
             }
           },
-          "defaultConfiguration": ""
+          "defaultConfiguration": "production"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
@@ -70,8 +72,12 @@
           "configurations": {
             "production": {
               "buildTarget": "klimabuergerrat-offener-brief:build:production"
+            },
+            "development": {
+              "buildTarget": "klimabuergerrat-offener-brief:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,11 @@
 export const environment = {
-  production: true
+  production: true,
+  contentful: {
+    space: '5z21gx3h7sb2',
+    environment: 'master',
+    accessToken: 'ecQ2l4UMTYi1MU3Szr2iNLep8Ak_pNp5i3Nxe1qU3VA',
+  },
+  mailService: {
+    url: 'https://open-letter-mailer.herokuapp.com'
+  }
 };


### PR DESCRIPTION
environment.prod.ts only defined `production: true`, so any production build failed to compile with TS2339 where the code reads `environment.contentful` and `environment.mailService`. That had been worked around by setting `defaultConfiguration` to "", which made `npm run build` - used by both CI and heroku-postbuild - emit an unoptimized bundle with sourcemaps and no output hashing.

- Populate environment.prod.ts with the Contentful and mail-service config, copied from environment.ts (the values production already ran on, so behaviour is unchanged)
- Set the build target's defaultConfiguration to "production"
- Add the standard "development" configuration holding the previous dev-flavoured base options, and point `serve` at it so `ng serve` is unaffected

Production output drops from 3.19 MB to 868 kB (199 kB gzip), ships no sourcemaps, and applies file hashing.