### PR TITLE
Refresh project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development server
+npx ng serve            # http://localhost:4200 (defaults to the `development` configuration)
+
+# Build
+npm run build           # defaults to the `production` configuration → dist/
+npx ng build --configuration development   # unoptimized build with source maps
+
+# Unit tests (Jest)
+npm test                # watch mode
+npm run test:prod       # single run, no watch
+npm test -- --testPathPattern=<file>   # single spec file
+npm test -- --testNamePattern="<name>" # single test by name
+
+# E2E tests (Playwright – auto-starts dev server)
+npm run playwright:install  # one-time browser install
+npm run e2e
+
+# Lint
+npm run lint
+
+# Production server
+npm start               # Express server (serves dist/)
+```
+
+Node 22.x — the version CI runs and the version the Heroku build targets.
+
+## Architecture
+
+Angular 20 SPA for collecting signatures on an open letter about climate policy ("Klimabürgerrat offener Brief"). The user-facing content and UI are in German.
+
+**NgModule-based, not standalone.** Despite being on Angular 20, this app uses the classic module architecture: `src/main.ts` bootstraps via `platformBrowserDynamic().bootstrapModule(AppModule)`, with `src/app/app.module.ts` and `src/app/app-routing.module.ts`. No component sets `standalone: true`. New components must be declared in `AppModule` — do not generate standalone components or migrate to `bootstrapApplication` without a deliberate decision to convert the whole app.
+
+**Content:** All editable content (the letter text, signees, privacy policy, legal notice) lives in Contentful (headless CMS). The `ContentfulService` (`src/app/contentful.service.ts`) fetches this data; environment files hold the space/access-token credentials.
+
+**Credentials are committed on purpose.** `src/environments/environment.ts` and `environment.prod.ts` both contain the same Contentful space ID and access token. This is a read-only Content Delivery API token for a public website, not a leaked secret — removing it or moving it to an unset environment variable will break the build and the live site.
+
+**Routing:** `src/app/app-routing.module.ts` defines `/impressum` (`ImpressumComponent`), `/datenschutz` (`DataprivacyComponent`), and a `**` wildcard mapping everything else to `LetterComponent` (letter + signature form). There is deliberately no 404 route — any unrecognized URL renders the letter.
+
+**Signing flow:** The `sign-letter-modal` component collects user input and calls a mail service URL (configured in `environment.ts`) to persist a new signature. The mail service is a separate Heroku app, `open-letter-mailer`.
+
+**Production serving:** `server.js` is an Express wrapper that serves `dist/`, enforces HTTPS on Heroku, and falls back to `index.html` for SPA routing.
+
+**Styling:** Bootstrap 5 (via angular.json asset), ng-bootstrap for Angular components, FontAwesome icons, global `styles.css`.
+
+**Testing:**
+- Unit tests: `src/**/*.spec.ts` with Jest + jest-preset-angular (JSDOM)
+- E2E tests: `e2e/app.spec.ts` with Playwright (Chromium, base URL `http://127.0.0.1:4200`)
+
+## Deployment
+
+The frontend deploys to the Heroku app **`open-letter-frontend`**, live at
+[klima-rat.org](https://klima-rat.org) (and `open-letter-frontend.herokuapp.com`).
+
+- Heroku's GitHub integration **auto-deploys on push to `master`** — merging a PR ships to
+  production. There is no `main` branch in this repo.
+- Heroku builds with the `heroku-postbuild` script (`ng build`) and serves the result via
+  `server.js`.
+- CI (`.github/workflows/node.js.yml`) runs build, `npm run test:prod`, and
+  `npm audit --audit-level=high --omit=dev` on pushes and PRs to `master`. It has **no** deploy
+  step, and Heroku deploys independently of whether CI passed.
+- Roll back a bad release without touching git:
+  `heroku releases:rollback --app open-letter-frontend`.

--- a/README-old.md
+++ b/README-old.md
@@ -1,2 +1,0 @@
-# klimabuergerrat-offener-brief
-Eine simple Website für die Darstellung und Verbreitung des offenen Briefs für einen Klimabürgerrat in Deutschland

--- a/README.md
+++ b/README.md
@@ -1,27 +1,88 @@
-# KlimabuergerratOffenerBrief
+# klimabuergerrat-offener-brief
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 10.1.2.
+Eine simple Website für die Darstellung und Verbreitung des offenen Briefs für einen
+Klimabürgerrat in Deutschland.
+
+Live at **[klima-rat.org](https://klima-rat.org)**.
+
+An Angular single-page app that presents an open letter on climate policy and collects
+signatures for it. The letter text, the list of signees, and the legal pages are maintained in
+[Contentful](https://www.contentful.com/) rather than in this repository, so the content can be
+edited without a deploy.
+
+## Prerequisites
+
+- Node.js 22.x (the version used by CI and by the production build)
+- npm
+
+## Setup
+
+```bash
+npm ci
+```
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+```bash
+npx ng serve
+```
 
-## Code scaffolding
-
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Navigate to `http://localhost:4200/`. The app reloads automatically when you change a source
+file. `ng serve` uses the `development` configuration (source maps, no optimization).
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+```bash
+npm run build
+```
+
+Build artifacts are written to `dist/`. `npm run build` uses the `production` configuration by
+default. For an unoptimized build with source maps:
+
+```bash
+npx ng build --configuration development
+```
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+Unit tests run on [Jest](https://jestjs.io/) (via jest-preset-angular):
+
+```bash
+npm test          # watch mode
+npm run test:prod # single run, used by CI
+```
 
 ## Running end-to-end tests
 
-Run `npm run e2e` to execute the end-to-end tests via [Playwright](https://playwright.dev/).
+End-to-end tests run on [Playwright](https://playwright.dev/) and start the dev server
+automatically:
+
+```bash
+npm run playwright:install  # one-time browser download
+npm run e2e
+```
+
+## Deployment
+
+The app is hosted on Heroku and deploys automatically when commits land on `master`. Heroku
+builds via the `heroku-postbuild` script and serves the result through `server.js`, a small
+Express wrapper that enforces HTTPS and handles SPA routing.
+
+Continuous integration (`.github/workflows/node.js.yml`) builds the app, runs the unit tests, and
+audits production dependencies on every push and pull request to `master`.
+
+## Editing content
+
+The letter, the signees, the privacy policy, and the legal notice all live in Contentful and are
+fetched at runtime by `ContentfulService` (`src/app/contentful.service.ts`). Changes made in
+Contentful appear on the live site without a redeploy.
+
+## Contributing
+
+Issues and pull requests are welcome. Please see [SECURITY.md](SECURITY.md) for how to report a
+vulnerability.
 
 ## Further help
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+For help with the Angular CLI, run `ng help` or see the
+[Angular CLI documentation](https://angular.dev/cli).


### PR DESCRIPTION
## Why

`README.md` still described the project as it was generated years ago. Three of its statements were factually wrong:

| Line | Said | Reality |
|---|---|---|
| 3 | generated with Angular CLI 10.1.2 | Angular 20.3.18 |
| 19 | unit tests via Karma | migrated to Jest in `83d1a16` |
| 15 | use the `--prod` flag | removed in Angular 12+; `ng build` now defaults to production |

## What changed

- **`README.md`** rewritten against the current stack (Angular 20, Jest, Playwright), with the prerequisites, deployment, and content-editing sections that were missing entirely.
- **`README-old.md`** deleted; its German project description is folded into `README.md`, since it was the better summary of what this project actually is.
- **`CLAUDE.md`** committed for the first time. Beyond the commands and architecture notes, it documents three things that are easy to get wrong here:
  - this is an **NgModule** app despite being on Angular 20 (`platformBrowserDynamic().bootstrapModule`), so an agent assuming standalone components will generate code that does not fit;
  - the committed Contentful token is a **read-only Content Delivery API token for a public site**, not a leaked secret — removing it breaks the build and the live site;
  - the **Heroku deployment**: auto-deploy on push to `master`, no deploy step in CI, and `heroku releases:rollback` as the escape hatch.
- Corrects the routing description: the third route is a `**` wildcard mapping everything to `LetterComponent`, so there is deliberately no 404.

## Risk

Documentation only — no source or build files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)