### PR TITLE
Add unit test coverage for the signature submission flow

### DIFF
--- a/src/app/contentful.service.spec.ts
+++ b/src/app/contentful.service.spec.ts
@@ -1,16 +1,82 @@
 import { TestBed } from '@angular/core/testing';
+import { createClient } from 'contentful';
 
 import { ContentfulService } from './contentful.service';
 
+jest.mock('contentful', () => ({
+  createClient: jest.fn(),
+}));
+
 describe('ContentfulService', () => {
   let service: ContentfulService;
+  let getEntryMock: jest.Mock;
 
   beforeEach(() => {
+    getEntryMock = jest.fn();
+    (createClient as jest.Mock).mockReturnValue({ getEntry: getEntryMock });
+
     TestBed.configureTestingModule({});
     service = TestBed.inject(ContentfulService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('getLetter fetches the letter entry by id', async () => {
+    const entry = { fields: { text: 'Liebe Leserinnen und Leser' } };
+    getEntryMock.mockResolvedValue(entry);
+
+    const result = await service.getLetter();
+
+    expect(getEntryMock).toHaveBeenCalledWith('2aDDbb4AjEQdCo0IW7AnLm');
+    expect(result).toBe(entry);
+  });
+
+  it('getImpressum fetches the impressum entry by id', async () => {
+    const entry = { fields: { text: 'Impressum' } };
+    getEntryMock.mockResolvedValue(entry);
+
+    const result = await service.getImpressum();
+
+    expect(getEntryMock).toHaveBeenCalledWith('1RjJ8ucJJIekoeZ6Tz1ZLH');
+    expect(result).toBe(entry);
+  });
+
+  it('getDataprivacy fetches the dataprivacy entry by id', async () => {
+    const entry = { fields: { text: 'Datenschutz' } };
+    getEntryMock.mockResolvedValue(entry);
+
+    const result = await service.getDataprivacy();
+
+    expect(getEntryMock).toHaveBeenCalledWith('4rC21AGeBowVcfQKLnwBPk');
+    expect(result).toBe(entry);
+  });
+
+  it('getProgressbar fetches the progressbar entry by id', async () => {
+    const entry = { fields: { phases: [], numberOfActivePhase: 1 } };
+    getEntryMock.mockResolvedValue(entry);
+
+    const result = await service.getProgressbar();
+
+    expect(getEntryMock).toHaveBeenCalledWith('1YkTzVK4KBzfmsMyBqKSo8');
+    expect(result).toBe(entry);
+  });
+
+  it('resolves with whatever the client returns for an entry with empty fields', async () => {
+    const emptyEntry = { fields: {} };
+    getEntryMock.mockResolvedValue(emptyEntry);
+
+    const result = await service.getLetter();
+
+    expect(result).toBe(emptyEntry);
+  });
+
+  it('propagates a rejected getEntry call, e.g. when the entry does not exist', async () => {
+    getEntryMock.mockRejectedValue(new Error('The resource could not be found'));
+
+    await expect(service.getImpressum()).rejects.toThrow(
+      'The resource could not be found'
+    );
   });
 });

--- a/src/app/sign-letter-modal/sign-letter-modal.component.spec.ts
+++ b/src/app/sign-letter-modal/sign-letter-modal.component.spec.ts
@@ -1,0 +1,154 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+
+import { SignLetterModalComponent } from './sign-letter-modal.component';
+import { environment } from '../../environments/environment';
+
+describe('SignLetterModalComponent', () => {
+  let component: SignLetterModalComponent;
+  let fixture: ComponentFixture<SignLetterModalComponent>;
+  let httpMock: HttpTestingController;
+  let modalServiceMock: { open: jest.Mock };
+  const signeeUrl = `${environment.mailService.url}/signee`;
+
+  beforeEach(async () => {
+    modalServiceMock = { open: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      declarations: [SignLetterModalComponent],
+      imports: [FormsModule, FontAwesomeModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: NgbModal, useValue: modalServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SignLetterModalComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('onSubmit', () => {
+    it('posts the form as FormData to the mail service signee endpoint', () => {
+      component.form = { organisation: 'Test Org', email: 'test@example.com' };
+
+      component.onSubmit();
+
+      const req = httpMock.expectOne(signeeUrl);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toBeInstanceOf(FormData);
+      expect(req.request.body.get('organisation')).toBe('Test Org');
+      expect(req.request.body.get('email')).toBe('test@example.com');
+
+      req.flush({});
+    });
+
+    it('sets loading to true while the request is in flight', () => {
+      component.form = { organisation: 'Test Org' };
+
+      component.onSubmit();
+
+      expect(component.loading).toBe(true);
+
+      const req = httpMock.expectOne(signeeUrl);
+      req.flush({});
+    });
+
+    it('on success sets formSubmitted, clears errorMessage and resets loading', () => {
+      component.errorMessage = 'stale error';
+      component.form = { organisation: 'Test Org' };
+
+      component.onSubmit();
+
+      const req = httpMock.expectOne(signeeUrl);
+      req.flush({});
+
+      expect(component.formSubmitted).toBe(true);
+      expect(component.errorMessage).toBe('');
+      expect(component.loading).toBe(false);
+    });
+
+    it('on error sets the German error message, leaves formSubmitted false and resets loading', () => {
+      component.form = { organisation: 'Test Org' };
+
+      component.onSubmit();
+
+      const req = httpMock.expectOne(signeeUrl);
+      req.flush('failure', { status: 500, statusText: 'Server Error' });
+
+      expect(component.formSubmitted).toBe(false);
+      expect(component.loading).toBe(false);
+      expect(component.errorMessage).toBe(
+        'Deine Zeichnung konnte nicht übermittelt werden. Versuche es später noch einmal oder wende direkt an kontakt@klima-rat.org. Vielen Dank für Dein Verständnis.'
+      );
+    });
+
+    it('appends a previously selected logo file under the logo key', () => {
+      const file = new File(['logo-bytes'], 'logo.png', { type: 'image/png' });
+      component.form = { organisation: 'Test Org', logo: file };
+
+      component.onSubmit();
+
+      const req = httpMock.expectOne(signeeUrl);
+      expect(req.request.body.get('logo')).toBe(file);
+
+      req.flush({});
+    });
+  });
+
+  describe('onFileSelect', () => {
+    it('stores the first selected file under the logo key', () => {
+      const file = new File(['data'], 'logo.png', { type: 'image/png' });
+      const event = { target: { files: [file] } };
+
+      component.onFileSelect(event);
+
+      expect(component.form['logo']).toBe(file);
+    });
+
+    it('does nothing when the file list is empty', () => {
+      const event = { target: { files: [] } };
+
+      component.onFileSelect(event);
+
+      expect(component.form['logo']).toBeUndefined();
+    });
+  });
+
+  describe('open', () => {
+    it('resets form, errorMessage, formSubmitted and loading when the modal closes', async () => {
+      component.form = { organisation: 'stale' };
+      component.errorMessage = 'stale error';
+      component.formSubmitted = true;
+      component.loading = true;
+
+      const modalRef = { result: Promise.resolve('Mitzeichnen erfolgreich abgeschlossen') };
+      modalServiceMock.open.mockReturnValue(modalRef);
+
+      component.open({});
+      await modalRef.result;
+
+      expect(component.form).toEqual({});
+      expect(component.errorMessage).toBe('');
+      expect(component.formSubmitted).toBe(false);
+      expect(component.loading).toBe(false);
+    });
+  });
+});

--- a/src/app/sign-letter-modal/sign-letter-modal.component.spec.ts
+++ b/src/app/sign-letter-modal/sign-letter-modal.component.spec.ts
@@ -86,6 +86,7 @@ describe('SignLetterModalComponent', () => {
     });
 
     it('on error sets the German error message, leaves formSubmitted false and resets loading', () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
       component.form = { organisation: 'Test Org' };
 
       component.onSubmit();
@@ -93,6 +94,7 @@ describe('SignLetterModalComponent', () => {
       const req = httpMock.expectOne(signeeUrl);
       req.flush('failure', { status: 500, statusText: 'Server Error' });
 
+      consoleError.mockRestore();
       expect(component.formSubmitted).toBe(false);
       expect(component.loading).toBe(false);
       expect(component.errorMessage).toBe(


### PR DESCRIPTION
## Summary
- `sign-letter-modal.component.ts` was at 0% coverage despite being the only code path that accepts public input and posts it to a backend (issue #100 item 1). Adds tests for `onSubmit()`'s FormData POST, success/error state transitions, the in-flight `loading` state, `onFileSelect()`, and `open()`'s reset-on-close.
- `contentful.service.ts` previously had only a `should be created` smoke test (issue #100 item 2). Adds real behavioural tests for all four fetch methods (`getLetter`, `getImpressum`, `getDataprivacy`, `getProgressbar`) against a mocked Contentful client, including an empty-fields and a rejected-entry case.
- All HTTP/Contentful calls are mocked (`HttpTestingController`, `jest.mock('contentful')`) — nothing hits the live `open-letter-mailer` backend or Contentful, per the issue's explicit note.
- No production code changed.

Overall coverage: 35.32% → 58.15% statements, 10.66% → 16% branches.

## Out of scope
Issue #100 item 3 (an e2e happy-path test through the sign modal) is intentionally **not** included here. The "Jetzt mitzeichnen!" button has a hardcoded, unconditional `disabled` attribute (`sign-letter-modal.component.html:210`), so it can't currently be driven through a real e2e interaction — native disabled buttons don't dispatch click events even under Playwright's `force: true`. That's tracked separately in #102, which asks whoever owns the project to confirm whether signing should currently be enabled.

## Test plan
- [x] `npm run test:prod` — 10 suites, 25 tests, all passing
- [x] `npm run build` — production build succeeds
- [x] Code review via subagent — no Critical/Important issues; one Minor (console noise in the error-path test) fixed in a follow-up commit

Closes #100.